### PR TITLE
Add support for .NET 7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,44 @@
+*.swp
+*.*~
+project.lock.json
+.DS_Store
+*.pyc
+nupkg/
+
+# Visual Studio Code
+.vscode
+
+# Rider
+.idea
+
+# User-specific files
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+build/
+bld/
+[Bb]in/
+[Oo]bj/
+[Oo]ut/
+msbuild.log
+msbuild.err
+msbuild.wrn
+
+# Visual Studio 2015
+.vs/
+
+# Archivo de variables
+*.env
+
+# Configuración personalizada
+appsettings.*.json
+launchSettings.json

--- a/ArcShapeFile.NET7.csproj
+++ b/ArcShapeFile.NET7.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net7.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<Version>8.0.5027</Version>
+		<SignAssembly>True</SignAssembly>
+		<AssemblyOriginatorKeyFile>ArcShapeFile.snk</AssemblyOriginatorKeyFile>
+		<ApplicationIcon>ShapeOCX.ico</ApplicationIcon>
+	</PropertyGroup>
+	<ItemGroup>
+	  <None Remove="ESRIGeo.txt" />
+	  <None Remove="ESRIProj.txt" />
+	</ItemGroup>
+	<ItemGroup>
+	  <Content Include="ShapeOCX.ico" />
+	</ItemGroup>
+	<ItemGroup>
+	  <EmbeddedResource Include="ESRIGeo.txt" />
+	  <EmbeddedResource Include="ESRIProj.txt" />
+	</ItemGroup>
+</Project>

--- a/Projection.cs
+++ b/Projection.cs
@@ -222,5 +222,8 @@ namespace ArcShapeFile
 
         #endregion
 
+        public string WKT { get; set; } = string.Empty;
+
+        public int EPSG { get; set; }
     }
 }

--- a/WKTReader.cs
+++ b/WKTReader.cs
@@ -441,7 +441,10 @@ namespace ArcShapeFile
             return RetString;
         }
 
-
+        public void LoadWKT(string wkt)
+        {
+            throw new System.NotImplementedException();
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Hi!

I recently created a new project file targeting .NET 7 (SDK style) and implemented a `.gitignore` file to exclude non-essential files. However, I encountered a compilation issue in my development environment. The Projection class appeared to be missing the `WKT` and `EPSG` properties, and the `WKTReader` class lacked the `LoadWKT` method.

The absence of `LoadWKT` is concerning because using `myShape.WriteProjection(eGeocentricDatums.GCS_WGS_1984)` doesn't generate the project file, while `myShape.WriteProjection("GEOGCS...")` functions as expected.

I added the properties and the method (empty).

While I understand this project may not be actively maintained, I intend to contribute future commits to enhance its functionality.

:grin: